### PR TITLE
 Bump requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,4 +218,4 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 ## Upgrade Notice 
 
 ### 1.1.3 
-Pressbooks LTI Provider requires requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0
+Pressbooks LTI Provider requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pressbooks LTI Provider 
 **Contributors:** conner_bw, greatislander  
 **Tags:** pressbooks, lti, lms  
-**Requires at least:** 5.0.3  
-**Tested up to:** 5.0.3  
+**Requires at least:** 5.1.0  
+**Tested up to:** 5.1.0  
 **Stable tag:** 1.1.3  
 **License:** GPLv3 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
@@ -218,4 +218,4 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 ## Upgrade Notice 
 
 ### 1.1.3 
-Pressbooks LTI Provider requires requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+Pressbooks LTI Provider requires requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** pressbooks, lti, lms  
 **Requires at least:** 5.1.0  
 **Tested up to:** 5.1.0  
-**Stable tag:** 1.1.3  
+**Stable tag:** 1.2.0  
 **License:** GPLv3 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 
 ## Changelog 
 
+### 1.2.0 
+ * Refactor code to respect Pressbooks coding standards 1.0.0
+ * Fix an issue with GitHub updater not always working
+ * Update Common Cartridge to work with Pressbooks 5.7 Exports page: #31
+ * Update dependencies to latest versions
+
+
 ### 1.1.3 
  * Update izumi-kun/lti to version 1.1.6 (fix properties of class ContentItemPlacement)
  * Update README
@@ -217,5 +224,5 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 
 ## Upgrade Notice 
 
-### 1.1.3 
+### 1.2.0 
 Pressbooks LTI Provider requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/pressbooks-lti-provider.php
+++ b/pressbooks-lti-provider.php
@@ -7,7 +7,7 @@ Version: 1.1.3
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Requires PHP: 7.1
-Pressbooks tested up to: 5.6.5
+Pressbooks tested up to: 5.7.0
 Text Domain: pressbooks-lti-provider
 License: GPLv3 or later
 Network: True

--- a/pressbooks-lti-provider.php
+++ b/pressbooks-lti-provider.php
@@ -3,7 +3,7 @@
 Plugin Name: Pressbooks LTI Provider
 Plugin URI: https://pressbooks.org
 Description: A plugin which turns Pressbooks into an LTI provider.
-Version: 1.1.3
+Version: 1.2.0
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Requires PHP: 7.1

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Pressbooks LTI Provider ===
 Contributors: conner_bw, greatislander
 Tags: pressbooks, lti, lms
-Requires at least: 5.0.3
-Tested up to: 5.0.3
+Requires at least: 5.1.0
+Tested up to: 5.1.0
 Stable tag: 1.1.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -196,4 +196,4 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 
 == Upgrade Notice ==
 = 1.1.3 =
-Pressbooks LTI Provider requires requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+Pressbooks LTI Provider requires requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: conner_bw, greatislander
 Tags: pressbooks, lti, lms
 Requires at least: 5.1.0
 Tested up to: 5.1.0
-Stable tag: 1.1.3
+Stable tag: 1.2.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,12 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 ![ContentItemSelectionRequest in Moodle.](screenshot-3.png)
 
 == Changelog ==
+= 1.2.0 =
+ * Refactor code to respect Pressbooks coding standards 1.0.0
+ * Fix an issue with GitHub updater not always working
+ * Update Common Cartridge to work with Pressbooks 5.7 Exports page: #31
+ * Update dependencies to latest versions
+
 = 1.1.3 =
  * Update izumi-kun/lti to version 1.1.6 (fix properties of class ContentItemPlacement)
  * Update README
@@ -195,5 +201,5 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
  * Initial scaffold.
 
 == Upgrade Notice ==
-= 1.1.3 =
+= 1.2.0 =
 Pressbooks LTI Provider requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/readme.txt
+++ b/readme.txt
@@ -196,4 +196,4 @@ Thanks to [Ed Beck](http://ed-beck.com/), [Bracken Mosbacker](https://github.com
 
 == Upgrade Notice ==
 = 1.1.3 =
-Pressbooks LTI Provider requires requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0
+Pressbooks LTI Provider requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0


### PR DESCRIPTION
Pressbooks LTI Provider requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0
