### PR TITLE
Updated travis api key syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ before_deploy:
 deploy:
   provider: releases
   skip_cleanup: true
-  api_key:
-    secure: $GITHUB_ACCESS_TOKEN
+  api_key: $GITHUB_ACCESS_TOKEN
   file: "pressbooks-lti-provider-$TRAVIS_TAG.zip"
   on:
     tags: true


### PR DESCRIPTION
I updated the travis.yml API key on deploy syntax since Travis build is nagging because it's out of date.