### PR TITLE
Restore role match on login

### DIFF
--- a/inc/class-tool.php
+++ b/inc/class-tool.php
@@ -444,12 +444,7 @@ class Tool extends ToolProvider\ToolProvider {
 	public function loginUser( $wp_user, $lti_id, $lti_id_was_matched, $role ) {
 		if ( $role !== 'anonymous' ) {
 			if ( is_user_member_of_blog( $wp_user->ID ) ) {
-				// Change role of an existing Pressbooks user to the one provided by the LMS.
-				//
-				// Our customers don't want this behaviour. The LTI certification suite (probably) does...
-				// Commenting out, instead of removing, for future facepalm.
-				//
-				// $wp_user->set_role( $role ); // @codingStandardsIgnoreLine
+				$wp_user->set_role( $role );
 			} else {
 				add_user_to_blog( get_current_blog_id(), $wp_user->ID, $role );
 			}


### PR DESCRIPTION
This PR fixed the user role matching got LTI connections.

**No need to test locally.**